### PR TITLE
Replaced '.load' with '.on('load')'

### DIFF
--- a/src/horizon-swiper.js
+++ b/src/horizon-swiper.js
@@ -109,7 +109,7 @@
         that.init();
       });
 
-      defaults.$window.load(function () {
+      defaults.$window.on('load', function () {
         windowLoadFunction();
       });
     }


### PR DESCRIPTION
Replaced deprecated event ".load( handler )" with ".on( "load", handler )" so Swiper can work with the latest jQuery 3.0+ (tested with 3.6.0) now.

> Note: This API has been removed in jQuery 3.0; please use .on( "load", handler ) instead of .load( handler ) and .trigger( "load" ) instead of .load().

https://api.jquery.com/load-event/